### PR TITLE
Zero and infinite SEs

### DIFF
--- a/R/compute_summary_results_normal.R
+++ b/R/compute_summary_results_normal.R
@@ -27,9 +27,10 @@ wpost_normal <- function(x, s, w, a) {
   lf <- dnorm(x, 0, s, log = TRUE)
   wpost <- w / (w + (1 - w) * exp(lf - lg))
 
-  # Deal with zero sds:
+  # Deal with zero and infinite sds:
   wpost[s == 0 & x == 0] <- 0
   wpost[s == 0 & x != 0] <- 1
+  wpost[is.infinite(s)] <- w
 
   return(wpost)
 }
@@ -45,5 +46,8 @@ pmean_cond_normal <- function(x, s, a) {
 #  Calculate the posterior variance for non-zero effect
 #
 pvar_cond_normal <- function(s, a) {
-  return(s^2 / (1 + s^2 * a))
+  pvar_cond <- s^2 / (1 + s^2 * a)
+  pvar_cond[is.infinite(s)] <- 1 / a
+
+  return(pvar_cond)
 }

--- a/R/loglik_normal.R
+++ b/R/loglik_normal.R
@@ -25,7 +25,7 @@ vloglik_normal = function(x, s, w, a) {
 
   # Deal with zero sds:
   result[s == 0 & x == 0] <- log(1 - w)
-  result[s == 0 & x != 0] <- log(w) + lg
+  result[s == 0 & x != 0] <- log(w) + lg[s == 0 & x != 0]
 
   return(result)
 }


### PR DESCRIPTION
Allow ebnm_point_normal to accept observations with infinite SEs (just returns the mean and variance of the prior). Fix bug in calculation of log likelihood when there are SEs equal to zero.